### PR TITLE
Append a Z to implicit UTC DateTime Strings from SQLite

### DIFF
--- a/plugin/src/main/kotlin/com/chimerapps/storageinspector/ui/ide/view/sql/CustomDataTableView.kt
+++ b/plugin/src/main/kotlin/com/chimerapps/storageinspector/ui/ide/view/sql/CustomDataTableView.kt
@@ -338,7 +338,16 @@ private class TableViewColumnInfo(
     }
 
     private fun parseDateTime(raw: String): Long {
-        return OffsetDateTime.parse(raw).toInstant().toEpochMilli();
+        // If the DateTime ends with a Z or a time zone (e.g. +00:00), parse it
+        // If not, assume that it is in UTC (per SQLite convention) and append a Z before parsing it
+        val pattern = Pattern.compile(".*(\\+\\d{2}:\\d{2}|Z)$");
+        return if (pattern.matcher(raw).find()) {
+            // Already correctly formatted
+            OffsetDateTime.parse(raw).toInstant().toEpochMilli();
+        } else {
+            // Not correctly formatted yet, append a Z to treat it as UTC
+            OffsetDateTime.parse(raw+"Z").toInstant().toEpochMilli();
+        }
     }
 
     override fun isCellEditable(item: TableRow): Boolean {


### PR DESCRIPTION
This way, the DateTimes will be parsed correctly by the plugin

Helps to solve the new issue that came up in #1 

Hopefully this can get #2 to a point where it works as expected

While this works as expected in an isolated IntelliJ project, I was not able to get the plugin working locally, so I haven't been able to test it for "real".